### PR TITLE
require 'rspec/expectations'

### DIFF
--- a/lib/rspec-spies.rb
+++ b/lib/rspec-spies.rb
@@ -15,6 +15,7 @@ RSpec::Mocks::MethodDouble.class_eval do
   end
 end
 
+require 'rspec/expectations'
 require 'rspec/matchers'
 RSpec::Matchers.module_eval do
   def have_received(sym, &block)


### PR DESCRIPTION
`rspec/matchers` which is the only thing required by rspec-spies has a dependency on `rspec/expectatoins`

Most of the time you don't see this because rspec is loaded before rspec-spies. If the inverse is true, then you can an expection. It could be argued that the flaw is in rspec, and that `rspec/matchers` should require `rspec/expectations` itself, but I'm not sure if it was intended to be an independently loadable module.
