### PR TITLE
Add argument expectation matcher support

### DIFF
--- a/lib/rspec-spies.rb
+++ b/lib/rspec-spies.rb
@@ -15,6 +15,21 @@ RSpec::Mocks::MethodDouble.class_eval do
   end
 end
 
+require 'rspec/mocks/argument_expectation'
+require 'rspec/mocks/proxy'
+RSpec::Mocks::Proxy.class_eval do
+  # override message received check to compare arguments using argument expectations
+  def received_message?(method_name, *args, &block)
+    args_expectation = RSpec::Mocks::ArgumentExpectation.new(*args)
+
+    @messages_received.any? do |(received_method_name, received_args, received_block)|
+      received_method_name == method_name &&
+      args_expectation.args_match?(*received_args) &&
+      received_block == block
+    end
+  end
+end
+
 require 'rspec/matchers'
 RSpec::Matchers.module_eval do
   def have_received(sym, &block)

--- a/spec/rspec-spies_spec.rb
+++ b/spec/rspec-spies_spec.rb
@@ -44,7 +44,34 @@ module Spec
         message  = messages[:failure_message_for_should_not].call(@object)
         message.should == "expected \"HI!\" to not have received :slice with [1, 2], but did"
       end
-    end
 
+      it "does match if method is called with args that match basic argument expectations" do
+        @object.stub!(:concat)
+        @object.concat("def")
+
+        have_received(:concat).with(kind_of(String)).matches?(@object).should be_true
+      end
+
+      it "does match if method is called with args that match a no_args argument expectation" do
+        @object.stub!(:downcase)
+        @object.downcase
+
+        have_received(:downcase).with(no_args).matches?(@object).should be_true
+      end
+
+      it "does match if method is called with args that match a any_args argument expectation" do
+        @object.stub!(:slice)
+        @object.slice(3, 5)
+
+        have_received(:slice).with(any_args).matches?(@object).should be_true
+      end
+
+      it "does match if method is called with args that match a regex arguement expectation" do
+        @object.stub!(:concat)
+        @object.concat("def")
+
+        have_received(:concat).with(/e/).matches?(@object).should be_true
+      end
+    end
   end
 end

--- a/spec/rspec-spies_spec.rb
+++ b/spec/rspec-spies_spec.rb
@@ -66,6 +66,13 @@ module Spec
         have_received(:slice).with(any_args).matches?(@object).should be_true
       end
 
+      it "does match if method is called with args that match a anything argument expectation" do
+        @object.stub!(:slice)
+        @object.slice(3, 5)
+
+        have_received(:slice).with(anything, anything).matches?(@object).should be_true
+      end
+
       it "does match if method is called with args that match a regex arguement expectation" do
         @object.stub!(:concat)
         @object.concat("def")


### PR DESCRIPTION
Support argument expectation matchers and not just literal values. Matchers like kind_of, no_args, any_args, and regexes.
