### PR TITLE
Supports rspec 2.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source :rubygems
+
 gem 'rspec', '~> 2.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
+  remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
+    diff-lcs (1.1.3)
     git (1.2.5)
     jeweler (1.6.4)
       bundler (~> 1.0)
@@ -8,14 +9,14 @@ GEM
       rake
     rake (0.9.2)
     rdoc (3.6.1)
-    rspec (2.6.0)
-      rspec-core (~> 2.6.0)
-      rspec-expectations (~> 2.6.0)
-      rspec-mocks (~> 2.6.0)
-    rspec-core (2.6.4)
-    rspec-expectations (2.6.0)
+    rspec (2.8.0)
+      rspec-core (~> 2.8.0)
+      rspec-expectations (~> 2.8.0)
+      rspec-mocks (~> 2.8.0)
+    rspec-core (2.8.0)
+    rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
-    rspec-mocks (2.6.0)
+    rspec-mocks (2.8.0)
 
 PLATFORMS
   ruby

--- a/lib/rspec-spies.rb
+++ b/lib/rspec-spies.rb
@@ -10,39 +10,35 @@ RSpec::Mocks::MethodDouble.class_eval do
          __mock_proxy.record_message_received :#{method_name}, *args, &block
          __mock_proxy.message_received :#{method_name}, *args, &block
        end
-       #{visibility_for_method}
+    #{visibility_for_method}
     EOF
   end
 end
 
 require 'rspec/matchers'
-RSpec::Matchers.module_eval do
-  def have_received(sym, &block)
-    RSpec::Matchers::Matcher.new :have_received, sym, @args, block do |sym, args, block|
-      match do |actual|
-        actual.received_message?(sym, *@args, &block)
-      end
+RSpec::Matchers.define :have_received do |sym, args, block|
+  match do |actual|
+    actual.received_message?(sym, *@args, &block)
+  end
 
 
-      failure_message_for_should do |actual|
-        "expected #{actual.inspect} to have received #{sym.inspect} with #{@args.inspect}"
-      end
+  failure_message_for_should do |actual|
+    "expected #{actual.inspect} to have received #{sym.inspect} with #{@args.inspect}"
+  end
 
 
-      failure_message_for_should_not do |actual|
-        "expected #{actual.inspect} to not have received #{sym.inspect} with #{@args.inspect}, but did"
-      end
+  failure_message_for_should_not do |actual|
+    "expected #{actual.inspect} to not have received #{sym.inspect} with #{@args.inspect}, but did"
+  end
 
 
-      description do
-        "to have received #{sym.inspect} with #{args.inspect}"
-      end
+  description do
+    "to have received #{sym.inspect} with #{args.inspect}"
+  end
 
 
-      def with(*args)
-        @args = args
-        self
-      end
-    end
+  def with(*args)
+    @args = args
+    self
   end
 end


### PR DESCRIPTION
- Updates Gemfile.lock to point to 2.8
- Defines matcher using preferred rspec syntax
- Still works against older versions of rspec (tested against 2.6)
