### PR TITLE
Use message expectation API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
-    rake (0.9.2)
+    rake (0.9.2.2)
     rdoc (3.6.1)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)

--- a/lib/rspec-spies.rb
+++ b/lib/rspec-spies.rb
@@ -4,12 +4,16 @@ class RSpec::Mocks::Proxy
 
   attr_reader :messages_received, :error_generator
 
+  # This is the same as the original MethodDouble monkey patch, but with less copypasta
   alias orig_message_received message_received
-
-  # This does the equivalent of the original MethodDouble monkey patch, but with
-  # less copying/work
   def message_received(*args, &block)
     orig_message_received(*args, &block).tap { record_message_received(*args, &block) }
+  end
+
+  # Be sure to reset the messages received between specs!
+  alias orig_reset reset
+  def reset
+    orig_reset.tap { messages_received.clear }
   end
 
 end

--- a/spec/rspec-spies_spec.rb
+++ b/spec/rspec-spies_spec.rb
@@ -1,60 +1,64 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
-module Spec
-  module Matchers
-    describe "[object.should] have_received(method, *args)" do
-      before do
-        @object = String.new("HI!")
-      end
+describe "[object.should] have_received(method, *args)" do
 
-      it "does match if method is called with correct args" do
-        @object.stub!(:slice)
-        @object.slice(5)
-
-        have_received(:slice).with(5).matches?(@object).should be_true
-      end
-
-      it "does not match if method is called with incorrect args" do
-        @object.stub!(:slice)
-        @object.slice(3)
-
-        have_received(:slice).with(5).matches?(@object).should be_false
-      end
-
-      it "does not match if method is not called" do
-        @object.stub!(:slice)
-
-        have_received(:slice).with(5).matches?(@object).should be_false
-      end
-
-      it "correctly lists expects arguments for should" do
-        @object.stub!(:slice)
-
-        matcher  = have_received(:slice).with(5, 3)
-        messages = matcher.instance_variable_get("@messages")
-        message  = messages[:failure_message_for_should].call(@object)
-        message.should == "expected \"HI!\" to have received :slice with [5, 3]"
-      end
-
-      it "doesn't show nil for arguments in description" do
-        @object.stub!(:slice)
-
-        @object.slice(3)
-        matcher = have_received(:slice).with(3)
-        messages = matcher.instance_variable_get("@messages")
-        message = messages[:description].call(@object)
-        message.should_not include "nil"
-      end
-
-      it "correctly lists expects arguments for should_not" do
-        @object.stub!(:slice)
-
-        matcher  = have_received(:slice).with(1, 2)
-        messages = matcher.instance_variable_get("@messages")
-        message  = messages[:failure_message_for_should_not].call(@object)
-        message.should == "expected \"HI!\" to not have received :slice with [1, 2], but did"
-      end
-    end
-
+  before do
+    @object = String.new("HI!")
+    @object.stub!(:slice)
   end
+
+  it "does match if method is called with correct args" do
+    @object.slice(5)
+
+    have_received(:slice).with(5).matches?(@object).should be_true
+  end
+
+  it "does not match if method is called with incorrect args" do
+    @object.slice(3)
+
+    have_received(:slice).with(5).matches?(@object).should be_false
+  end
+
+  it "does not match if method is not called" do
+    have_received(:slice).with(5).matches?(@object).should be_false
+  end
+
+  it "correctly lists expects arguments for should" do
+    matcher  = have_received(:slice).with(5, 3)
+    matcher.matches?(@object).should be_false
+    message = matcher.failure_message_for_should
+    message.should =~ /\(HI!\).slice\(5, 3\).*expected: 1 time.*received: 0 times/m
+  end
+
+  it "correctly lists expects arguments for should_not" do
+    @object.slice(1,2)
+
+    matcher  = have_received(:slice).with(1, 2)
+    matcher.matches?(@object).should be_true
+    message = matcher.failure_message_for_should_not
+    message.should =~ /\(HI!\).slice\(1, 2\).*unexpected match/m
+  end
+
+  it "allows omitting argument matchers" do
+    @object.slice(5)
+
+    have_received(:slice).matches?(@object).should be_true
+  end
+
+
+  it "allows specifying counts" do
+    @object.slice(5)
+
+    have_received(:slice).at_least(:twice).matches?(@object).should be_false
+  end
+
+  it "allows using args matchers" do
+    m = double.as_null_object
+    m.validate = true
+
+    have_received(:validate=).with(boolean).matches?(m).should be_true
+  end
+
 end
+
+


### PR DESCRIPTION
This PR rewrites rspec-spies to make `#have_received` reuse RSpec's message expectation API.

It also removes the copy-paste monkey-patching, hopefully improving its future-proofiness. (Though to be fair it does introduce a few new monkey patches -- mostly exposing mock proxy state.)

Feel free to reject this PR if it's too broad.
