### PR TITLE
remove circular dependency

### DIFF
--- a/rspec-spies.gemspec
+++ b/rspec-spies.gemspec
@@ -44,14 +44,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rspec-spies>, [">= 0"])
       s.add_runtime_dependency(%q<rspec>, ["~> 2.0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, [">= 0"])
       s.add_development_dependency(%q<appraisal>, [">= 0"])
     else
-      s.add_dependency(%q<rspec-spies>, [">= 0"])
       s.add_dependency(%q<rspec>, ["~> 2.0"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
@@ -59,7 +57,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<appraisal>, [">= 0"])
     end
   else
-    s.add_dependency(%q<rspec-spies>, [">= 0"])
     s.add_dependency(%q<rspec>, ["~> 2.0"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])


### PR DESCRIPTION
rspec-spies is not working with JRuby-1.7.0. If rspec-spies have been required, it was happend to "stack level too deep". this problem is caused to rspec-spies.gemspec includes self gems.

I removed self dependency. Please accept it.
