### PR TITLE
Reset stubs on class methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,28 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    appraisal (0.4.1)
+    appraisal (0.5.1)
       bundler
       rake
     diff-lcs (1.1.3)
     git (1.2.5)
-    jeweler (1.6.4)
+    jeweler (1.8.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
-    rake (0.9.2)
-    rdoc (3.6.1)
-    rspec (2.8.0)
-      rspec-core (~> 2.8.0)
-      rspec-expectations (~> 2.8.0)
-      rspec-mocks (~> 2.8.0)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
+      rdoc
+    json (1.7.7)
+    rake (10.0.3)
+    rdoc (3.12.1)
+      json (~> 1.4)
+    rspec (2.12.0)
+      rspec-core (~> 2.12.0)
+      rspec-expectations (~> 2.12.0)
+      rspec-mocks (~> 2.12.0)
+    rspec-core (2.12.2)
+    rspec-expectations (2.12.1)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.12.2)
 
 PLATFORMS
   ruby

--- a/spec/rspec-spies_spec.rb
+++ b/spec/rspec-spies_spec.rb
@@ -79,5 +79,21 @@ module Spec
       end
     end
 
+    describe 'clearing out received messages' do
+      class Foo; end
+
+      before do
+        Foo.stub(:party)
+      end
+
+      it 'base case' do
+        Foo.party
+        have_received(:party).matches?(Foo).should be_true
+      end
+
+      it 'does not match even if the class method has been called in another spec' do
+        have_received(:party).matches?(Foo).should be_false
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixed https://github.com/technicalpickles/rspec-spies/issues/17
Note: a test in this commit fails with rspec < 2.11 since stubbing constants was not supported before that.
