### PR TITLE
Mimic RSpec's exactly(x).times matcher

### DIFF
--- a/lib/rspec-spies.rb
+++ b/lib/rspec-spies.rb
@@ -33,12 +33,17 @@ end
 
 RSpec::Matchers.define :have_received do |method_name, args, block|
   match do |actual|
-    messages_received = actual.send(:__mock_proxy).instance_variable_get("@messages_received")
-    messages_received.any? do |message|
+    messages_received = actual.send(:__mock_proxy).instance_variable_get("@messages_received").keep_if do |message|
       received_method_name, received_args, received_block = *message
       result = (received_method_name == method_name)
       result &&= argument_expectation_class.new(@args || any_args).args_match?(received_args)
       result &&= (received_block == block)
+    end
+
+    if @times
+      messages_received.length == @expected_count
+    else
+      messages_received.length > 0
     end
   end
 
@@ -46,8 +51,16 @@ RSpec::Matchers.define :have_received do |method_name, args, block|
     @args = args
   end
 
+  chain :exactly do |count|
+    @expected_count = count
+  end
+
+  chain :times do
+    @times = true
+  end
+
   failure_message_for_should do |actual|
-    "expected #{actual.inspect} to have received #{method_name.inspect}#{args_message}"
+    "expected #{actual.inspect} to have received #{method_name.inspect}#{args_message}#{times_message}"
   end
 
   failure_message_for_should_not do |actual|
@@ -60,5 +73,9 @@ RSpec::Matchers.define :have_received do |method_name, args, block|
 
   def args_message
     @args ? " with #{@args.inspect}" : ""
+  end
+
+  def times_message
+    @times ? " exactly #{@expected_count} times" : ""
   end
 end

--- a/lib/rspec-spies.rb
+++ b/lib/rspec-spies.rb
@@ -33,7 +33,8 @@ end
 
 RSpec::Matchers.define :have_received do |method_name, args, block|
   match do |actual|
-    messages_received = actual.send(:__mock_proxy).instance_variable_get("@messages_received").keep_if do |message|
+    @messages_received = actual.send(:__mock_proxy).instance_variable_get("@messages_received").dup
+    @messages_received.keep_if do |message|
       received_method_name, received_args, received_block = *message
       result = (received_method_name == method_name)
       result &&= argument_expectation_class.new(@args || any_args).args_match?(received_args)
@@ -41,9 +42,9 @@ RSpec::Matchers.define :have_received do |method_name, args, block|
     end
 
     if @times
-      messages_received.length == @expected_count
+      @messages_received.length == @expected_count
     else
-      messages_received.length > 0
+      @messages_received.length > 0
     end
   end
 
@@ -76,6 +77,6 @@ RSpec::Matchers.define :have_received do |method_name, args, block|
   end
 
   def times_message
-    @times ? " exactly #{@expected_count} times" : ""
+    @times ? " exactly #{@expected_count} times but was called #{@messages_received.count} times" : ""
   end
 end

--- a/spec/rspec-spies_spec.rb
+++ b/spec/rspec-spies_spec.rb
@@ -47,6 +47,17 @@ module Spec
         have_received(:slice).exactly(3).times.matches?(@object).should be_false
       end
 
+      it "matches if called multiple times with different arguments" do
+        @object.stub!(:slice)
+        @object.slice(1)
+        @object.slice(2)
+
+        have_received(:slice).with(1).matches?(@object).should be_true
+        have_received(:slice).with(2).matches?(@object).should be_true
+        have_received(:slice).with(3).matches?(@object).should be_false
+      end
+
+
       it "does not match if method is called with incorrect args" do
         @object.stub!(:slice)
         @object.slice(3)

--- a/spec/rspec-spies_spec.rb
+++ b/spec/rspec-spies_spec.rb
@@ -37,6 +37,16 @@ module Spec
         have_received(:slice).with(hash_including({ :foo => :baz })).matches?(@object).should be_false
       end
 
+      it "matches if specifies exactly(x).times" do
+        @object.stub!(:slice)
+        @object.slice(5)
+        @object.slice(5)
+
+        have_received(:slice).exactly(1).times.matches?(@object).should be_false
+        have_received(:slice).exactly(2).times.matches?(@object).should be_true
+        have_received(:slice).exactly(3).times.matches?(@object).should be_false
+      end
+
       it "does not match if method is called with incorrect args" do
         @object.stub!(:slice)
         @object.slice(3)


### PR DESCRIPTION
This adds the ability to use RSpec-like (exact) receive counts. Thanks @alenia
