### PR TITLE
can assert on non-block arguments when method is called with a block

### DIFF
--- a/lib/rspec-spies.rb
+++ b/lib/rspec-spies.rb
@@ -38,7 +38,6 @@ RSpec::Matchers.define :have_received do |method_name, args, block|
       received_method_name, received_args, received_block = *message
       result = (received_method_name == method_name)
       result &&= argument_expectation_class.new(@args || any_args).args_match?(received_args)
-      result &&= (received_block == block)
     end
   end
 

--- a/spec/rspec-spies_spec.rb
+++ b/spec/rspec-spies_spec.rb
@@ -37,6 +37,14 @@ module Spec
         have_received(:slice).with(hash_including({ :foo => :baz })).matches?(@object).should be_false
       end
 
+      it "matches if third argument is a block" do
+        @object.stub!(:slice)
+        @object.slice(5) do; end
+
+        have_received(:slice).with(5).matches?(@object).should be_true
+        have_received(:slice).with(5,anything).matches?(@object).should be_false
+      end
+
       it "does not match if method is called with incorrect args" do
         @object.stub!(:slice)
         @object.slice(3)


### PR DESCRIPTION
A line in the matcher prevented assertions on the arguments of a method that was called with a block.
